### PR TITLE
Configure for WPA2 AES encryption

### DIFF
--- a/bash_script/wifi_extender.bash
+++ b/bash_script/wifi_extender.bash
@@ -98,6 +98,9 @@ config_wpsup() {
         echo '  ssid="'${NEW_SSID}'"'
         echo "  mode=2"
         echo "  key_mgmt=WPA-PSK"
+        echo "  proto=RSN"
+        echo "  pairwise=CCMP"
+        echo "  group=CCMP"
         echo '  psk='`generate_wpa2_psk $NEW_SSID $NEW_PASS`
         echo "  frequency=2412"
         echo "}"


### PR DESCRIPTION
Current AP code uses a lower security encryption than the standard WIFI encryption standard of WPA2 (AES).  This change will configure the AP to WPA2 (AES).